### PR TITLE
FIX: Remove underscore versions of TextareaTextManipulation functions

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -55,13 +55,19 @@ function initializeCodeByte(api) {
 
       this.onSaveResponse = (message) => {
         if (message.data.codeByteSaveResponse) {
-          const editableCodebytes = Array.from(
-            this.element.querySelectorAll(
-              '.d-editor-preview .d-codebyte iframe'
-            )
+          const editableCodebyteFrames = this.element?.querySelectorAll(
+            '.d-editor-preview .d-codebyte iframe'
+          );
+
+          if (!editableCodebyteFrames) {
+            return;
+          }
+
+          const codebyteWindows = Array.from(
+            editableCodebyteFrames
           ).map((frame) => frame.contentWindow);
 
-          const index = editableCodebytes.indexOf(message.source);
+          const index = codebyteWindows.indexOf(message.source);
           if (index >= 0) {
             this.send(
               'updateCodeByte',

--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -86,8 +86,8 @@ function initializeCodeByte(api) {
         let startTag = '[codebyte]\n';
         let endTag = '\n[/codebyte]';
 
-        const lineValueSelection = this._getSelected('', { lineVal: true });
-        const selection = this._getSelected();
+        const lineValueSelection = this.getSelected('', { lineVal: true });
+        const selection = this.getSelected();
         const addBlockInSameline = lineValueSelection.lineVal.length === 0;
         const isTextSelected = selection.value.length > 0;
         const isWholeLineSelected =
@@ -119,7 +119,7 @@ function initializeCodeByte(api) {
           if (!newLineAfterSelection) {
             exampleFormat = exampleFormat + '\n';
           }
-          this._insertText(exampleFormat);
+          this.insertText(exampleFormat);
         }
       },
       updateCodeByte(index, { text, language }) {

--- a/test/javascripts/acceptance/codebytes-test.js
+++ b/test/javascripts/acceptance/codebytes-test.js
@@ -4,6 +4,8 @@ import {
   queryAll,
   visible 
 } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { click, currentURL, fillIn, triggerEvent, visit } from "@ember/test-helpers";
 
 acceptance("CodeBytes", function (needs) {
   needs.user();
@@ -44,9 +46,8 @@ acceptance("CodeBytes", function (needs) {
       '[codebyte]\n\n[/codebyte]'
     );
 
-    assert.equal(
-      queryAll(".d-editor-preview .d-codebyte iframe").attr('src'),
-      "https://www.codecademy.com/codebyte-editor?lang=&text=",
+    assert.ok(
+      queryAll(".d-editor-preview .d-codebyte iframe").attr('src').startsWith("https://www.codecademy.com/codebyte-editor"),
       "it renders an iframe pointing to the codebyte editor on codecademy.com"
     );
   });


### PR DESCRIPTION
Related change here: https://github.com/discourse/discourse/commit/94207e27d16f120fe8ce01e9542ded41118bccbc