### PR TITLE
DEV: Plugin rename

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# name: CodeBytes
+# name: discourse-codebytes-plugin
 # about: Adds executable code blocks
 # version: 0.1
 # authors: Codecademy


### PR DESCRIPTION
Running `CI=1 QUNIT_EMBER_CLI=1 bundle exec rake plugin:qunit['discourse-codebytes-plugin','900000']` caused a problem in our build because the plugin name did not match the repo name.