### PR TITLE
FIX: Update decorator for core change

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -197,10 +197,9 @@ function initializeCodeByte(api) {
   api.decorateCookedElement(
     (elem, decoratorHelper) => {
       const isPreview = elem.classList.contains("d-editor-preview");
-      const postUrl = decoratorHelper
-        ? `${document.location.origin}${
-            decoratorHelper.getModel().urlWithNumber
-          }`
+      const post = decoratorHelper?.getModel();
+      const postUrl = post
+        ? `${document.location.origin}${post.urlWithNumber}`
         : document.location.href;
       elem.querySelectorAll("div.d-codebyte").forEach(async (div) => {
         const codebyteFrame = await renderCodebyteFrame(


### PR DESCRIPTION
Following https://github.com/discourse/discourse/commit/54b1e3195c7cbc3df223f2dd932a830e888eb33c, the decoratorHelper is now available even outside the post-stream. Therefore its presence can no longer be used as a proxy for "are we in the post stream". Instead, we can check for the existence of the post model.

  